### PR TITLE
Feat & Fix: Anniversary 컴포넌트 구현

### DIFF
--- a/src/components/Main/Anniversary.js
+++ b/src/components/Main/Anniversary.js
@@ -1,5 +1,178 @@
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
+import styled from "styled-components";
+import { useRecoilState } from "recoil";
+import { useNavigate } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-const Anniversary = ({ anniversary }) => {};
+// ===== styles import =====
+import P from "../../styles/TextStyle";
+import FlexBox from "../../styles/FlexStyle";
+import { Button } from "../../styles/ButtonStyle";
+import AlertModal from "../Modal/AlertModal";
+
+import { faPenToSquare } from "@fortawesome/free-solid-svg-icons"; // 수정 아이콘
+
+// ===== components import =====
+import InputField from "../Common/InputField";
+import ErrorMessage from "../Common/ErrorMessage";
+
+// ===== recoil & utils import =====
+import { isClickedEditButton } from "../../recoil/editButtonState";
+import { calculateAnniversary } from "../../utils/calculation";
+
+// ===== style =====
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
+  width: 24px;
+  height: 24px;
+  color: #d9d9d9;
+`;
+
+// ===== component =====
+const Anniversary = ({ anniversary }) => {
+  // === ref ===
+  const firstDayRef = useRef("");
+
+  // === state ===
+  const [isNicknameEditMode, setIsNicknameEditMode] = useState(false);
+  const [isToggledEditButton, setIsToggledEditButton] = useRecoilState(isClickedEditButton);
+  const [anniversaryError, setAnniversaryError] = useState("");
+  const [tokenErrorModalOpen, setTokenErrorModalOpen] = useState(false);
+  const [ourAnniversary, setOurAnniversary] = useState("");
+
+  // === navigate ===
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // 기념일 수정 성공 시, 수정 사항 반영
+    // 기념일 수정 실패 시, Error Message 출력
+    setOurAnniversary(anniversary);
+  }, [anniversary]);
+
+  // 수정 버튼 클릭 시
+  const handleClickEditModeButton = () => {
+    setIsNicknameEditMode(true);
+    setIsToggledEditButton((prevState) => ({
+      ...prevState,
+      isNicknameEditButtonVisible: false,
+      isThumbnailEditButtonVisible: false,
+    }));
+  };
+
+  // 취소 버튼 클릭 시
+  const handleClickCancelButton = () => {
+    const firstDay = firstDayRef.current.value;
+
+    if (firstDay.trim() === "") {
+      setAnniversaryError("입력한 기념일을 다시 확인해 주세요.");
+    } else {
+      setIsNicknameEditMode(false);
+
+      setIsToggledEditButton((prevState) => ({
+        ...prevState,
+        isNicknameEditButtonVisible: true,
+        isThumbnailEditButtonVisible: true,
+      }));
+    }
+  };
+
+  // 저장 버튼 클릭 시
+  const handleClickSaveButton = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const firstDay = firstDayRef.current.value;
+
+    const daysUntilAnniversary = calculateAnniversary(firstDay, today);
+
+    if (firstDay.trim() === "") {
+      setAnniversaryError("입력한 기념일을 다시 확인해 주세요.");
+    } else {
+      // 연애 날짜 수정하기 API 호출 코드
+      const status = 200;
+
+      if (status === 400) {
+        setAnniversaryError("입력한 기념일을 다시 확인해 주세요.");
+      } else if (status === 401) {
+        setTokenErrorModalOpen(true);
+      } else if (status === 403) {
+        setAnniversaryError("우리의 기념일만 수정 가능합니다.");
+      } else if (status === 404) {
+        setAnniversaryError("입력한 기념일을 다시 확인해 주세요.");
+      } else if (status === 500) {
+        return;
+      } else {
+        setIsNicknameEditMode(false);
+        setOurAnniversary(daysUntilAnniversary);
+
+        setIsToggledEditButton((prevState) => ({
+          ...prevState,
+          isNicknameEditButtonVisible: true,
+          isThumbnailEditButtonVisible: true,
+        }));
+      }
+    }
+  };
+
+  const handleCloseErrorModal = () => {
+    navigate("/login");
+  };
+
+  return (
+    <>
+      {tokenErrorModalOpen && (
+        <AlertModal hasFunc={true} message="로그인이 필요합니다." onClick={handleCloseErrorModal} />
+      )}
+
+      {isNicknameEditMode ? (
+        <>
+          <FlexBox $width="30.625rem" $row="between" $col="center">
+            <FlexBox $width="18.75rem">
+              <InputField type="date" inputRef={firstDayRef} />
+            </FlexBox>
+
+            <FlexBox $width="10.625rem" $row="between">
+              <Button
+                $width="5rem"
+                $height="4.375rem"
+                $fontSize="20px"
+                onClick={handleClickSaveButton}
+              >
+                저장
+              </Button>
+              <Button
+                $width="5rem"
+                $height="4.375rem"
+                $fontSize="20px"
+                $backgroundColor="#d9d9d9"
+                onClick={handleClickCancelButton}
+              >
+                취소
+              </Button>
+            </FlexBox>
+          </FlexBox>
+
+          <FlexBox $width="30.625rem">
+            {anniversaryError && <ErrorMessage message={anniversaryError} />}
+          </FlexBox>
+        </>
+      ) : (
+        <>
+          <FlexBox $width="11rem" $height="3.1rem" $row="between" $col="center">
+            <P $fontSize="36px">D + {ourAnniversary}</P>
+            {isToggledEditButton.isAnniversaryEditButtonVisible && (
+              <>
+                <Button
+                  $backgroundColor="transparent"
+                  $margin="1px 0 0 0"
+                  onClick={handleClickEditModeButton}
+                >
+                  <StyledFontAwesomeIcon icon={faPenToSquare} />
+                </Button>
+              </>
+            )}
+          </FlexBox>
+        </>
+      )}
+    </>
+  );
+};
 
 export default Anniversary;

--- a/src/components/Main/Anniversary.js
+++ b/src/components/Main/Anniversary.js
@@ -1,5 +1,5 @@
 import React from "react";
 
-const Anniversary = () => {};
+const Anniversary = ({ anniversary }) => {};
 
 export default Anniversary;

--- a/src/components/Main/Nav.js
+++ b/src/components/Main/Nav.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -10,21 +10,10 @@ import { faCalendarDays } from "@fortawesome/free-solid-svg-icons"; // 일정 �
 import { faImage } from "@fortawesome/free-solid-svg-icons"; // 피드 아이콘
 import { faComments } from "@fortawesome/free-solid-svg-icons"; // 문답 아이콘
 
-// ===== components import =====
-import AlertModal from "../Modal/AlertModal";
-
 // ===== component =====
 const Nav = () => {
-  // === state ===
-  const [isLogoutFailModal, setIsLogoutFailModal] = useState(false);
-
   // === navigate ===
   const navigate = useNavigate();
-
-  useEffect(() => {
-    // 로그아웃 성공 시, 로그아웃 처리
-    // 로그아웃 실패 시, modal 출력
-  }, []);
 
   // 일정 버튼 클릭 시, 일정 페이지로 이동
   const handleClickScheduleButton = () => {
@@ -41,24 +30,14 @@ const Nav = () => {
     navigate("/qnalist");
   };
 
-  // 로그아웃 버튼 클릭 시, 로그아웃 API 호출
+  // 로그아웃 버튼 클릭 시, 로그아웃 처리
   const handleClickLogoutButton = () => {
-    // 로그아웃 API 호출 코드
-    const status = 200;
-
-    if (status === 400) {
-      setIsLogoutFailModal(true);
-    } else {
-      navigate("/login");
-    }
+    // 토큰 삭제
+    navigate("/login");
   };
 
   return (
     <>
-      {isLogoutFailModal && (
-        <AlertModal message="로그아웃에 실패했습니다." setIsOpen={setIsLogoutFailModal} />
-      )}
-
       <FlexBox
         $dir="col"
         $row="between"

--- a/src/components/Main/NicknameWrapper.js
+++ b/src/components/Main/NicknameWrapper.js
@@ -1,5 +1,5 @@
 import React from "react";
 
-const NicknameWrapper = () => {};
+const NicknameWrapper = ({ myNickname, LoverNickname }) => {};
 
 export default NicknameWrapper;

--- a/src/components/Main/Thumbnail.js
+++ b/src/components/Main/Thumbnail.js
@@ -1,5 +1,5 @@
 import React from "react";
 
-const Thumbnail = () => {};
+const Thumbnail = ({ thumbnail }) => {};
 
 export default Thumbnail;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { RecoilRoot } from "recoil";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 
@@ -17,6 +18,8 @@ font
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
   </React.StrictMode>,
 );

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -5,6 +5,7 @@ import Nav from "../components/Main/Nav";
 import Anniversary from "../components/Main/Anniversary";
 import Thumbnail from "../components/Main/Thumbnail";
 import NicknameWrapper from "../components/Main/NicknameWrapper";
+import FlexBox from "../styles/FlexStyle";
 
 // ===== component =====
 const Main = () => {
@@ -20,6 +21,7 @@ const Main = () => {
       partnerNickname: "뿅아리",
       imageUrl: "",
       startDate: "123",
+      // 초기 정보가 yyyy-dd-mm 로 오는 경우, utils/calculation을 활용해 기념일 계산하여 props로 내려주기
     };
 
     setInitialData(data);
@@ -27,13 +29,20 @@ const Main = () => {
 
   return (
     <>
-      <Nav />
-      <Anniversary anniversary={initialData.startDate} />
-      <Thumbnail thumbnail={initialData.imageUrl} />
-      <NicknameWrapper
-        myNickname={initialData.myNickname}
-        LoverNickname={initialData.partnerNickname}
-      />
+      <FlexBox $width="100%">
+        {/* nav */}
+        <Nav />
+
+        {/* 기념일, 대표 사진, 애칭 */}
+        <FlexBox $dir="col" $width="100%" $col="center">
+          <Anniversary anniversary={initialData.startDate} />
+          <Thumbnail thumbnail={initialData.imageUrl} />
+          <NicknameWrapper
+            myNickname={initialData.myNickname}
+            LoverNickname={initialData.partnerNickname}
+          />
+        </FlexBox>
+      </FlexBox>
     </>
   );
 };

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 // ===== components import =====
 import Nav from "../components/Main/Nav";
@@ -8,12 +8,32 @@ import NicknameWrapper from "../components/Main/NicknameWrapper";
 
 // ===== component =====
 const Main = () => {
+  // === state ===
+  const [initialData, setInitialData] = useState([]);
+
+  useEffect(() => {
+    // 초기 정보 불러오기 성공 시, 각 컴포넌트에 데이터 뿌리기
+    // 초기 정보 불러오기 실패 시, modal 출력
+
+    const data = {
+      myNickname: "왕왕이",
+      partnerNickname: "뿅아리",
+      imageUrl: "",
+      startDate: "123",
+    };
+
+    setInitialData(data);
+  }, []);
+
   return (
     <>
       <Nav />
-      <Anniversary />
-      <Thumbnail />
-      <NicknameWrapper />
+      <Anniversary anniversary={initialData.startDate} />
+      <Thumbnail thumbnail={initialData.imageUrl} />
+      <NicknameWrapper
+        myNickname={initialData.myNickname}
+        LoverNickname={initialData.partnerNickname}
+      />
     </>
   );
 };

--- a/src/recoil/editButtonState.js
+++ b/src/recoil/editButtonState.js
@@ -1,0 +1,10 @@
+import { atom } from "recoil";
+
+export const isClickedEditButton = atom({
+  key: isClickedEditButton,
+  default: {
+    isAnniversaryEditButtonVisible: true,
+    isNicknameEditButtonVisible: true,
+    isThumbnailEditButtonVisible: true,
+  },
+});

--- a/src/recoil/editButtonState.js
+++ b/src/recoil/editButtonState.js
@@ -1,7 +1,7 @@
 import { atom } from "recoil";
 
 export const isClickedEditButton = atom({
-  key: isClickedEditButton,
+  key: "isClickedEditButton",
   default: {
     isAnniversaryEditButtonVisible: true,
     isNicknameEditButtonVisible: true,

--- a/src/utils/calculation.js
+++ b/src/utils/calculation.js
@@ -1,0 +1,12 @@
+// 이 파일은 숫자 계산을 위한 유틸 함수들을 모아놓은 파일입니다.
+
+// 기념일 계산
+export function calculateAnniversary(startDateStr, endDateStr) {
+  const startDate = new Date(startDateStr);
+  const endDate = new Date(endDateStr);
+
+  const differenceInTime = endDate.getTime() - startDate.getTime();
+  const differenceInDays = differenceInTime / (1000 * 3600 * 24) + 1;
+
+  return Math.floor(differenceInDays);
+}


### PR DESCRIPTION
Main 페이지 내에서 초기 정보 불러오는 api 호출 후,
각각의 Anniversary, NicknameWrapper, Thumbnail 컴포넌트 내에서 수정 api 호출하는 방식으로 구현

**Anniversary 컴포넌트 구현 시 중요사항**
1. editButtonState.js 추가: 메인 페이지 내 각 컴포넌트 내에서 수정 상태로 변경 시 다른 컴포넌트의 수정 버튼 없애는 용도로, useState로 구현 시 복잡해져서 recoil로 구현